### PR TITLE
Fix maximizing nested panes

### DIFF
--- a/stylesheets/layout-manager.less
+++ b/stylesheets/layout-manager.less
@@ -17,6 +17,8 @@ html.maximize-pane-on {
       left: 0;
       bottom: 0;
       z-index: 100;
+      
+      atom-pane-axis { display: none;}
     }
   }
 }

--- a/stylesheets/layout-manager.less
+++ b/stylesheets/layout-manager.less
@@ -7,6 +7,9 @@
 html.maximize-pane-on {
   .panes {
     position:relative;
+    .pane:not(.active){
+      display:none;
+    }
     .pane.active {
       position:absolute;
       top: 0;


### PR DESCRIPTION
When there are nested pane axes, maximize pane is only maximizing the current
axis. This fix hides panes in other axes.
